### PR TITLE
Update add subscription url for Standard and Enterprise API

### DIFF
--- a/example_scripts/webhook_management/add-enterprise-subscription.js
+++ b/example_scripts/webhook_management/add-enterprise-subscription.js
@@ -1,0 +1,32 @@
+var nconf = require('nconf')
+var request = require('request')
+
+
+// load config
+nconf.file({ file: 'config.json' }).env()
+
+// twitter authentication
+var twitter_oauth = {
+  consumer_key: nconf.get('TWITTER_CONSUMER_KEY'),
+  consumer_secret: nconf.get('TWITTER_CONSUMER_SECRET'),
+  token: nconf.get('TWITTER_ACCESS_TOKEN'),
+  token_secret: nconf.get('TWITTER_ACCESS_TOKEN_SECRET')
+}
+
+var WEBHOOK_ID = 'your-webhook-id'
+
+// request options
+var request_options = {
+  url: 'https://api.twitter.com/1.1/account_activity/webhooks/' + WEBHOOK_ID + '/subscriptions/all.json',
+  oauth: twitter_oauth
+}
+
+// POST request to create webhook config
+request.post(request_options, function (error, response, body) {
+
+  if (response.statusCode == 204) {
+    console.log('Subscription added.')
+  } else {
+    console.log('User has not authorized your app.')
+  }
+})

--- a/example_scripts/webhook_management/add-standard-subscription.js
+++ b/example_scripts/webhook_management/add-standard-subscription.js
@@ -13,12 +13,11 @@ var twitter_oauth = {
   token_secret: nconf.get('TWITTER_ACCESS_TOKEN_SECRET')
 }
 
-var WEBHOOK_ID = 'your-webhook-id'
-
+var ENV_NAME = 'your-env-name'
 
 // request options
 var request_options = {
-  url: 'https://api.twitter.com/1.1/account_activity/webhooks/' + WEBHOOK_ID + '/subscriptions.json',
+  url: 'https://api.twitter.com/1.1/account_activity/' + ENV_NAME + '/subscriptions.json',
   oauth: twitter_oauth
 }
 


### PR DESCRIPTION
Addressing issue #9 by creating separate files for adding subscriptions to your webhook via the Standard Account Activity API and the Enterprise Account Activity API 